### PR TITLE
fix: Trim trailing parenthesis that metadata api

### DIFF
--- a/scripts/update-metadata-json.ts
+++ b/scripts/update-metadata-json.ts
@@ -95,9 +95,11 @@ async function collectApis(files: Record<string, string>) {
             // Remove listeners for a cleaner API listing
             .replace(".addListener", "")
             // Trim any trailing dots
-            .replace(/\.$/, ""),
+            .replace(/\.$/, "")
+            // Trim any trailing parenthesis
+            .replace(/\)$/, "")
         );
-      },
+      }
     );
     apis.forEach((api) => {
       dirApis.add(api);


### PR DESCRIPTION
I noticed it in #4.