### PR TITLE
Clarify GitHub Actions reporter usage

### DIFF
--- a/examples/playwright-e2e-testing/playwright.config.ts
+++ b/examples/playwright-e2e-testing/playwright.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
 
   // Reporter to use
   reporter: "html",
+  // Use the 'github' for annotations in GitHub Actions
 
   use: {
     // Collect trace when retrying the failed test.

--- a/examples/playwright-e2e-testing/playwright.config.ts
+++ b/examples/playwright-e2e-testing/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
 
   // Reporter to use
   reporter: "html",
-  // Use the 'github' for annotations in GitHub Actions
+  // Use "github" if you want GitHub Actions annotations
 
   use: {
     // Collect trace when retrying the failed test.


### PR DESCRIPTION
The playwright [docs](https://playwright.dev/docs/test-reporters#github-actions-annotations) say:

> You can use the built in github reporter to get automatic failure annotations when running in GitHub actions.
> 
> Note that all other reporters work on GitHub Actions as well, but do not provide annotations. Also, it is not recommended to use this annotation type if running your tests with a matrix strategy as the stack trace failures will multiply and obscure the GitHub file view.
>
> ```ts
> import { defineConfig } from '@playwright/test';
> 
> export default defineConfig({
>   // 'github' for GitHub Actions CI to generate annotations, plus a concise 'dot'
>   // default 'list' when running locally
>   reporter: process.env.CI ? 'github' : 'list',
> });
> ```

Eg:

<img width="1434" height="500" alt="image" src="https://github.com/user-attachments/assets/fec6e8ae-d7e1-4dff-bc30-c83abdd4ecfb" />
